### PR TITLE
enables handling of float values and power calculations

### DIFF
--- a/lib/PHPMathParser/Expressions.php
+++ b/lib/PHPMathParser/Expressions.php
@@ -4,13 +4,13 @@ namespace PHPMathParser;
 
 class Parenthesis extends TerminalExpression {
 
-    protected $precidence = 6;
+    protected $precedence = 6;
 
     public function operate(Stack $stack) {
     }
 
-    public function getPrecidence() {
-        return $this->precidence;
+    public function getPrecedence() {
+        return $this->precedence;
     }
 
     public function isNoOp() {
@@ -37,11 +37,11 @@ class Number extends TerminalExpression {
 
 abstract class Operator extends TerminalExpression {
 
-    protected $precidence = 0;
+    protected $precedence = 0;
     protected $leftAssoc = true;
 
-    public function getPrecidence() {
-        return $this->precidence;
+    public function getPrecedence() {
+        return $this->precedence;
     }
 
     public function isLeftAssoc() {
@@ -56,7 +56,7 @@ abstract class Operator extends TerminalExpression {
 
 class Addition extends Operator {
 
-    protected $precidence = 4;
+    protected $precedence = 4;
 
     public function operate(Stack $stack) {
         return $stack->pop()->operate($stack) + $stack->pop()->operate($stack);
@@ -66,7 +66,7 @@ class Addition extends Operator {
 
 class Subtraction extends Operator {
 
-    protected $precidence = 4;
+    protected $precedence = 4;
 
     public function operate(Stack $stack) {
         $left = $stack->pop()->operate($stack);
@@ -78,7 +78,7 @@ class Subtraction extends Operator {
 
 class Multiplication extends Operator {
 
-    protected $precidence = 5;
+    protected $precedence = 5;
 
     public function operate(Stack $stack) {
         return $stack->pop()->operate($stack) * $stack->pop()->operate($stack);
@@ -88,7 +88,7 @@ class Multiplication extends Operator {
 
 class Division extends Operator {
 
-    protected $precidence = 5;
+    protected $precedence = 5;
 
     public function operate(Stack $stack) {
         $left = $stack->pop()->operate($stack);
@@ -100,7 +100,7 @@ class Division extends Operator {
 
 class Power extends Operator {
 
-    protected $precidence = 5;
+    protected $precedence = 5;
 
     public function operate(Stack $stack) {
         $left = $stack->pop()->operate($stack);

--- a/lib/PHPMathParser/Expressions.php
+++ b/lib/PHPMathParser/Expressions.php
@@ -97,3 +97,14 @@ class Division extends Operator {
     }
 
 }
+
+class Power extends Operator {
+
+    protected $precidence = 5;
+
+    public function operate(Stack $stack) {
+        $left = $stack->pop()->operate($stack);
+        $right = $stack->pop()->operate($stack);
+        return pow($left,$right);
+    }
+}

--- a/lib/PHPMathParser/Math.php
+++ b/lib/PHPMathParser/Math.php
@@ -112,7 +112,7 @@ class Math {
     }
 
     protected function tokenize($string) {
-        $parts = preg_split('((\d+|\+|-|\(|\)|\*|/)|\s+)', $string, null, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+        $parts = preg_split('((\f+|\+|-|\(|\)|\*|/)|\s+)', $string, null, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
         $parts = array_map('trim', $parts);
         return $parts;
     }

--- a/lib/PHPMathParser/Math.php
+++ b/lib/PHPMathParser/Math.php
@@ -112,7 +112,7 @@ class Math {
     }
 
     protected function tokenize($string) {
-        $parts = preg_split('((\f+|\+|-|\(|\)|\*|/)|\s+)', $string, null, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+        $parts = preg_split('((\f+|\+|-|\(|\)|\*|\^|/)|\s+)', $string, null, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
         $parts = array_map('trim', $parts);
         return $parts;
     }

--- a/lib/PHPMathParser/Math.php
+++ b/lib/PHPMathParser/Math.php
@@ -97,9 +97,9 @@ class Math {
             $operators->push($expression);
         } elseif ($end->isOperator()) {
             do {
-                if ($expression->isLeftAssoc() && $expression->getPrecidence() <= $end->getPrecidence()) {
+                if ($expression->isLeftAssoc() && $expression->getPrecedence() <= $end->getPrecedence()) {
                     $output->push($operators->pop());
-                } elseif (!$expression->isLeftAssoc() && $expression->getPrecidence() < $end->getPrecidence()) {
+                } elseif (!$expression->isLeftAssoc() && $expression->getPrecedence() < $end->getPrecedence()) {
                     $output->push($operators->pop());
                 } else {
                     break;

--- a/lib/PHPMathParser/TerminalExpression.php
+++ b/lib/PHPMathParser/TerminalExpression.php
@@ -11,6 +11,8 @@ abstract class TerminalExpression {
     }
 
     public static function factory($value) {
+
+        var_dump($value);
         if (is_object($value) && $value instanceof TerminalExpression) {
             return $value;
         } elseif (is_numeric($value)) {
@@ -25,6 +27,8 @@ abstract class TerminalExpression {
             return new Division($value);
         } elseif (in_array($value, array('(', ')'))) {
             return new Parenthesis($value);
+        } elseif ($value == '^') {
+            return new Power($value);
         }
         throw new \Exception('Undefined Value ' . $value);
     }


### PR DESCRIPTION
These commits enable the parser to tokenize floating numbers as well as ^ symbol to calculate power. I did not test with negative numbers.

Some code for testing:
> $math = new Math();
> $answer = $math->evaluate('1.25+2.75');
> var_dump($answer);

> $math = new Math();
> $answer = $math->evaluate('5^2');
> var_dump($answer);