### PR TITLE
Update Power Operator to have a higher precedence

### DIFF
--- a/lib/PHPMathParser/Expressions.php
+++ b/lib/PHPMathParser/Expressions.php
@@ -100,7 +100,7 @@ class Division extends Operator {
 
 class Power extends Operator {
 
-    protected $precedence = 5;
+    protected $precedence = 6;
 
     public function operate(Stack $stack) {
         $left = $stack->pop()->operate($stack);


### PR DESCRIPTION
Update Power Operator to have a higher precedence allowing for the calculation "1 + 1 - 4 * 4 ^ 2 / 2" to return the -30 correctly instead of -32766