### PR TITLE
Support Math Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 vendor
+
+# Netbeans
+/nbproject/private/
+project.properties
+project.xml
+/.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ vendor
 /nbproject/private/
 project.properties
 project.xml
-/.gitignore

--- a/lib/PHPMathParser/Expressions/MathFunction.php
+++ b/lib/PHPMathParser/Expressions/MathFunction.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * The PHP Math Parser library
+ *
+ * @author     Mohamed BOUDAOUI (motionSeed) <dev@motionseed.com>
+ * @copyright  2017 The Authors
+ * @license    http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @version    Build @@version@@
+ */
+namespace PHPMathParser\Expressions;
+
+use PHPMathParser\Stack;
+
+class MathFunction extends Operator
+{
+    protected $precedence = 10;
+    
+    protected static $functions = [
+        'ABS',
+        'COS', 'COSH', 'SIN', 'SINH', 'TAN', 'TANH', 'ACOS', 'ACOSH', 'ASIN', 'ASINH', 'ATAN', 'ATAN2', 'ATANH',
+        'DEG2GRAD', 'RAD2DEG', 'PI',
+        'CEIL', 'FLOOR', 'ROUND', 'SQRT', 'LOG10'
+    ];
+    
+    public static function isFunction($value)
+    {
+        return in_array($value, self::$functions);
+    }
+    
+    public function operate(Stack $stack)
+    {
+        $value = $stack->pop()->operate($stack);
+        
+        $function = strtolower($this->value);
+        
+        $result = new Number($function($value));
+        
+        return $result->operate($stack);
+    }
+}

--- a/lib/PHPMathParser/TerminalExpression.php
+++ b/lib/PHPMathParser/TerminalExpression.php
@@ -48,6 +48,8 @@ abstract class TerminalExpression
             return new Parenthesis($value);
         } elseif ($value == '^') {
             return new Power($value);
+        } elseif (MathFunction::isFunction($value)) {
+            return new MathFunction($value);
         }
         throw new \Exception('Undefined Value ' . $value);
     }

--- a/lib/PHPMathParser/TerminalExpression.php
+++ b/lib/PHPMathParser/TerminalExpression.php
@@ -18,6 +18,7 @@ use PHPMathParser\Expressions\Parenthesis;
 use PHPMathParser\Expressions\Power;
 use PHPMathParser\Expressions\Subtraction;
 use PHPMathParser\Expressions\Unary;
+use PHPMathParser\Expressions\MathFunction;
 
 abstract class TerminalExpression
 {

--- a/test.php
+++ b/test.php
@@ -99,3 +99,24 @@ $math = new Math();
 	$answer = $math->evaluate('($a + $a) * 4');
 	var_dump($answer);echo "<br /><br />";
 	// float(-44)
+    
+    // TEST added by motionSeed 
+    $math->registerVariable('a', 5);
+	$answer = $math->evaluate('10 + CEIL($a / 4)');
+	var_dump($answer);echo "<br /><br />";
+	// int(12)
+    
+    $math->registerVariable('a', 5);
+	$answer = $math->evaluate('10 + FLOOR($a / 4)');
+	var_dump($answer);echo "<br /><br />";
+	// int(11)
+    
+    $math->registerVariable('a', 9);
+	$answer = $math->evaluate('10 + SQRT($a)');
+	var_dump($answer);echo "<br /><br />";
+	// int(13)
+    
+    $math->registerVariable('a', 10);
+	$answer = $math->evaluate('10 + CEIL(SQRT($a))');
+	var_dump($answer);echo "<br /><br />";
+	// int(14)


### PR DESCRIPTION
Adding support to base math functions for the lib.

The functions must be named in UPPER case, and use the internal PHP function. 

For example, the ceil() function will be CEIL().

Expression : 10 + CEIL(SQRT(10)) will produce : 14

SQRT(10) -> 3.16 CEIL(3.16) -> 4 + 10 = 14

B. Mohamed - motionSeed